### PR TITLE
Refactor events with enums

### DIFF
--- a/src/Device/Device.h
+++ b/src/Device/Device.h
@@ -4,6 +4,7 @@
 #include <ArduinoJson.h>
 #include "../Utils/Button.h"
 #include "../Utils/Led.h"
+#include "../Events.h"
 
 class Device {
   protected:
@@ -16,9 +17,9 @@ class Device {
       : manualToggle(manualTogglePin), statusLed(statusLedPin) {}
     virtual void init() = 0;
     virtual void update() = 0;
-    virtual void on(const char* initiator) = 0;
-    virtual void off(const char* initiator) = 0;
-    virtual void toggle(const char* initiator) = 0;
+    virtual void on(EventInitiator initiator) = 0;
+    virtual void off(EventInitiator initiator) = 0;
+    virtual void toggle(EventInitiator initiator) = 0;
     virtual JsonDocument getJsonData() const = 0;
 
     bool getIsActive() const {

--- a/src/Device/Pump.cpp
+++ b/src/Device/Pump.cpp
@@ -14,7 +14,7 @@ void Pump::init() {
   statusLed.init();
 }
 
-void Pump::on(const char* initiator = EventInitiator::AUTO) {
+void Pump::on(EventInitiator initiator) {
   if (isActive) {
     COMM.send("Pump is already Off");
     return;
@@ -32,7 +32,7 @@ void Pump::on(const char* initiator = EventInitiator::AUTO) {
   COMM.sendEvent(Event::PUMP_ON, initiator);
 }
 
-void Pump::off(const char* initiator = EventInitiator::AUTO) {
+void Pump::off(EventInitiator initiator) {
   if (!isActive) {
     COMM.send("Pump is already Off");
     return;
@@ -61,7 +61,7 @@ void Pump::emergencyStop() {
   }
 }
 
-void Pump::toggle(const char* initiator = EventInitiator::AUTO) {
+void Pump::toggle(EventInitiator initiator) {
   if (isActive) {
     off(initiator);
   } else {

--- a/src/Device/Pump.h
+++ b/src/Device/Pump.h
@@ -15,9 +15,9 @@ class Pump : public Device {
 
     void init() override;
     void update() override;
-    void on(const char* initiator) override;
-    void off(const char* initiator) override;
-    void toggle(const char* initiator) override;
+    void on(EventInitiator initiator = EventInitiator::AUTO) override;
+    void off(EventInitiator initiator = EventInitiator::AUTO) override;
+    void toggle(EventInitiator initiator = EventInitiator::AUTO) override;
     JsonDocument getJsonData() const override;
 
     void emergencyStop();

--- a/src/Events.h
+++ b/src/Events.h
@@ -1,34 +1,75 @@
 #ifndef EVENTS_H
 #define EVENTS_H
 
-namespace EventInitiator {
-    constexpr const char* MANUAL   = "manual";
-    constexpr const char* AUTO     = "auto";
-    constexpr const char* SAFETY   = "safety";
-    constexpr const char* REMOTE   = "remote";
-  }
+#include <Arduino.h>
+#include <cstring>
 
-namespace Event {
-  constexpr const char* SYSTEM_STARTED  = "system_started";
-  constexpr const char* PUMP_ON    = "pump_on";
-  constexpr const char* PUMP_OFF    = "pump_off";
-  constexpr const char* PUMP_SAFETY_STOP= "pump_safety_stop";
-  constexpr const char* SYSTEM_LOCK= "system_lock";
-  constexpr const char* SYSTEM_UNLOCK= "system_unlock";
-  constexpr const char* MODE_AUTO= "mode_auto";
-  constexpr const char* MODE_MANUAL= "mode_manual";
+enum class EventInitiator {
+    MANUAL,
+    AUTO,
+    SAFETY,
+    REMOTE
+};
 
-  inline const char* getMessage(const char* event) {
-    if (event == SYSTEM_STARTED) return "System has started.";
-    if (event == PUMP_ON) return "Pump was turned on.";
-    if (event == PUMP_OFF) return "Pump was turned off.";
-    if (event == PUMP_SAFETY_STOP) return "Pump stopped for safety reasons.";
-    if (event == SYSTEM_LOCK) return "System is now Locked.";
-    if (event == SYSTEM_UNLOCK) return "System is now Unlocked.";
-    if (event == MODE_AUTO) return "Switching to Auto Mode.";
-    if (event == MODE_MANUAL) return "Switching to Manual Mode.";
+enum class Event {
+    SYSTEM_STARTED,
+    PUMP_ON,
+    PUMP_OFF,
+    PUMP_SAFETY_STOP,
+    SYSTEM_LOCK,
+    SYSTEM_UNLOCK,
+    MODE_AUTO,
+    MODE_MANUAL
+};
+
+inline const char* toString(EventInitiator initiator) {
+    switch (initiator) {
+        case EventInitiator::MANUAL: return "manual";
+        case EventInitiator::AUTO:   return "auto";
+        case EventInitiator::SAFETY: return "safety";
+        case EventInitiator::REMOTE: return "remote";
+    }
+    return "unknown";
+}
+
+inline const char* toString(Event event) {
+    switch (event) {
+        case Event::SYSTEM_STARTED:   return "system_started";
+        case Event::PUMP_ON:          return "pump_on";
+        case Event::PUMP_OFF:         return "pump_off";
+        case Event::PUMP_SAFETY_STOP: return "pump_safety_stop";
+        case Event::SYSTEM_LOCK:      return "system_lock";
+        case Event::SYSTEM_UNLOCK:    return "system_unlock";
+        case Event::MODE_AUTO:        return "mode_auto";
+        case Event::MODE_MANUAL:      return "mode_manual";
+    }
+    return "unknown";
+}
+
+inline const char* getMessage(Event event) {
+    switch (event) {
+        case Event::SYSTEM_STARTED:   return "System has started.";
+        case Event::PUMP_ON:          return "Pump was turned on.";
+        case Event::PUMP_OFF:         return "Pump was turned off.";
+        case Event::PUMP_SAFETY_STOP: return "Pump stopped for safety reasons.";
+        case Event::SYSTEM_LOCK:      return "System is now Locked.";
+        case Event::SYSTEM_UNLOCK:    return "System is now Unlocked.";
+        case Event::MODE_AUTO:        return "Switching to Auto Mode.";
+        case Event::MODE_MANUAL:      return "Switching to Manual Mode.";
+    }
     return "Unknown event.";
-  }
+}
+
+inline Event eventFromString(const char* id) {
+    if (strcmp(id, "system_started") == 0) return Event::SYSTEM_STARTED;
+    if (strcmp(id, "pump_on") == 0) return Event::PUMP_ON;
+    if (strcmp(id, "pump_off") == 0) return Event::PUMP_OFF;
+    if (strcmp(id, "pump_safety_stop") == 0) return Event::PUMP_SAFETY_STOP;
+    if (strcmp(id, "system_lock") == 0) return Event::SYSTEM_LOCK;
+    if (strcmp(id, "system_unlock") == 0) return Event::SYSTEM_UNLOCK;
+    if (strcmp(id, "mode_auto") == 0) return Event::MODE_AUTO;
+    if (strcmp(id, "mode_manual") == 0) return Event::MODE_MANUAL;
+    return Event::SYSTEM_STARTED;
 }
 
 #endif

--- a/src/Plant.cpp
+++ b/src/Plant.cpp
@@ -76,9 +76,9 @@ void Plant::addDevice(Device* device) {
 void Plant::executeCommand(const JsonDocument& doc) {
     const char* command = doc["command"];
 
-    if(strcmp(command, Event::PUMP_ON) == 0) {
+    if(strcmp(command, toString(Event::PUMP_ON)) == 0) {
         devices[0]->on(EventInitiator::REMOTE);
-    } else if (strcmp(command, Event::PUMP_OFF) == 0) {
+    } else if (strcmp(command, toString(Event::PUMP_OFF)) == 0) {
         devices[0]->off(EventInitiator::REMOTE);
     } else {
         COMM.send("Unknown Plant command!");

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -27,7 +27,7 @@ void System::update() {
     }
 }
 
-void System::lockDevice(const char* initiator = EventInitiator::AUTO) {
+void System::lockDevice(EventInitiator initiator) {
     if (!locked) {
         locked = true;
         systemLockedLed.on();
@@ -49,7 +49,7 @@ void System::unlockDevice() {
     COMM.send("Device is Already unlocked.");
 }
 
-void System::setAutoMode(const char* initiator = EventInitiator::AUTO) {
+void System::setAutoMode(EventInitiator initiator) {
     if (manualMode) {
         manualMode = false;
         modeLed.off();
@@ -60,7 +60,7 @@ void System::setAutoMode(const char* initiator = EventInitiator::AUTO) {
     COMM.send("Auto mode is already active.");
 }
 
-void System::setManualMode(const char* initiator = EventInitiator::AUTO) {
+void System::setManualMode(EventInitiator initiator) {
     if (!manualMode) {
         manualMode = true;
         modeLed.on();
@@ -71,7 +71,7 @@ void System::setManualMode(const char* initiator = EventInitiator::AUTO) {
     COMM.send("Manual mode is already active.");
 }
 
-void System::toggleMode(const char* initiator = EventInitiator::AUTO) {
+void System::toggleMode(EventInitiator initiator) {
     if(manualMode) {
         setAutoMode(initiator);
     } else {

--- a/src/System.h
+++ b/src/System.h
@@ -8,6 +8,7 @@
 #include "Utils/Button.h"
 #include "Utils/Led.h"
 #include "Plant.h"
+#include "Events.h"
 
 const int MODE_TOGGLE_PIN = 3;
 const int UNLOCK_BUTTON_PIN = 6;
@@ -21,12 +22,12 @@ public:
     void init();
     void update();
 
-    void lockDevice(const char* initiator);
+    void lockDevice(EventInitiator initiator = EventInitiator::AUTO);
     void unlockDevice();
 
-    void setAutoMode(const char* initiator);
-    void setManualMode(const char* initiator);
-    void toggleMode(const char* initiator);
+    void setAutoMode(EventInitiator initiator = EventInitiator::AUTO);
+    void setManualMode(EventInitiator initiator = EventInitiator::AUTO);
+    void toggleMode(EventInitiator initiator = EventInitiator::AUTO);
 
     void executeCommand(const JsonDocument& doc);
 

--- a/src/Utils/Comm.cpp
+++ b/src/Utils/Comm.cpp
@@ -19,12 +19,12 @@ void Comm::send(const char* msg) {
     Serial.println();
 }
 
-void Comm::sendEvent(const char* event, const char* initiator) {
+void Comm::sendEvent(Event event, EventInitiator initiator) {
     JsonDocument doc;
     doc["type"] = "event";
-    doc["eventId"] = event;
-    doc["message"] = Event::getMessage(event);
-    doc["initiator"] = initiator;
+    doc["eventId"] = toString(event);
+    doc["message"] = getMessage(event);
+    doc["initiator"] = toString(initiator);
     doc["timestamp"] = millis();
     serializeJson(doc, Serial);
     Serial.println();

--- a/src/Utils/Comm.h
+++ b/src/Utils/Comm.h
@@ -5,6 +5,7 @@
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#include "../Events.h"
 
 class Comm {
   public:
@@ -13,7 +14,7 @@ class Comm {
     void init(unsigned long baudRate = 9600);
 
     void send(const char* msg);
-    void sendEvent(const char* event, const char* initiator);
+    void sendEvent(Event event, EventInitiator initiator);
     void sendData(JsonDocument doc);
 
   private:


### PR DESCRIPTION
## Summary
- replace event string macros with enum classes
- update Comm and device interfaces to use enums
- adjust System, Plant, and Pump implementations

## Testing
- `g++ -c src/Utils/Comm.cpp -I./src -I/usr/lib/avr/include` *(fails: Arduino.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9665a3c0833096d84dae4cbf923b